### PR TITLE
fixed README (create_posts -> posts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ client.create_group(params)
 #### Search
 
 ```ruby
-client.create_posts(q: 'body')
-client.create_posts(q: 'body', page: 2)
-client.create_posts(q: 'body', page: 1, per_page: 100)
+client.posts(q: 'body')
+client.posts(q: 'body', page: 2)
+client.posts(q: 'body', page: 1, per_page: 100)
 ```
 
 #### Show


### PR DESCRIPTION
README 内の、メモ検索のメソッド名を修正しました。
create_posts -> posts