### PR TITLE
DocBaseAPIv2用の対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+
+* DocBaseAPIv2用としてリリース
+* チーム一覧APIを廃止
+* 環境変数`DOCBASE_ACCESS_TOKEN`でのトークン読み込みを廃止
+
 ## 1.0.0
 
 * DocBaseAPIv1用としてリリース

--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ Or install it yourself as:
 client = DocBase::Client.new(access_token: 'your_access_token', team: 'your_team')
 ```
 
-or
-
-```ruby
-ENV['DOCBASE_ACCESS_TOKEN'] = 'your_access_token'
-
-client = DocBase::Client.new(team: 'your_team')
-```
-
 ### users
 
 ```ruby
@@ -201,6 +193,7 @@ client.tags.body
 # => [{ name: 'ruby' }, { name: 'rails' }]
 
 client.team = 'danny'
+clinet.access_token = 'danny_team_access_token'
 client.tags.body
 # => [{ name: 'javascript' }, { name: 'react' }]
 ```

--- a/README.md
+++ b/README.md
@@ -34,13 +34,6 @@ ENV['DOCBASE_ACCESS_TOKEN'] = 'your_access_token'
 client = DocBase::Client.new(team: 'your_team')
 ```
 
-### teams
-
-```ruby
-client.teams.body
-# => [{ domain: 'kray', name: 'kray' }, { domain: 'danny', name: 'danny' }]
-```
-
 ### users
 
 ```ruby

--- a/lib/docbase/client.rb
+++ b/lib/docbase/client.rb
@@ -6,10 +6,10 @@ module DocBase
     class NotSetTeamError < StandardError; end
     class NotSetPostIdError < StandardError; end
 
-    attr_accessor :team
+    attr_accessor :team, :access_token
 
     def initialize(access_token: nil, url: nil, team: nil)
-      @access_token = access_token || ENV['DOCBASE_ACCESS_TOKEN']
+      self.access_token = access_token
       self.team = team
       @url = url || DEFAULT_URL
     end
@@ -131,7 +131,7 @@ module DocBase
       {
         'Accept'         => 'application/json',
         'User-Agent'     => USER_AGENT,
-        'X-DocBaseToken' => @access_token,
+        'X-DocBaseToken' => access_token,
         'X-Api-Version'  => 1,
       }
     end

--- a/lib/docbase/client.rb
+++ b/lib/docbase/client.rb
@@ -19,10 +19,6 @@ module DocBase
       @team
     end
 
-    def teams
-      connection.get('/teams')
-    end
-
     def users(q: nil, page: 1, per_page: 100, include_user_groups: false)
       connection.get("/teams/#{team!}/users", q: q, page: page, per_page: per_page, include_user_groups: include_user_groups)
     end

--- a/lib/docbase/client.rb
+++ b/lib/docbase/client.rb
@@ -132,7 +132,7 @@ module DocBase
         'Accept'         => 'application/json',
         'User-Agent'     => USER_AGENT,
         'X-DocBaseToken' => access_token,
-        'X-Api-Version'  => 1,
+        'X-Api-Version'  => 2,
       }
     end
   end

--- a/lib/docbase/version.rb
+++ b/lib/docbase/version.rb
@@ -1,3 +1,3 @@
 module DocBase
-  VERSION = '1.0.0'
+  VERSION = '2.0.0'
 end

--- a/spec/docbase/client_spec.rb
+++ b/spec/docbase/client_spec.rb
@@ -31,20 +31,6 @@ describe DocBase::Client do
     it { should eq(response_body) }
   end
 
-  describe '#teams' do
-    let(:path) { '/teams' }
-    let(:body) do
-      [
-       { domain: 'kray', name: 'kray' },
-       { domain: 'danny', name: 'danny' },
-      ]
-    end
-
-    let(:response_body) { client.teams.body }
-
-    it_behaves_like 'stub connection', { method: :get }
-  end
-
   describe '#tags' do
     let(:path) { "/teams/#{client.team}/tags" }
     let(:body) do


### PR DESCRIPTION
チーム一覧APIを廃止し、access_tokenを後から書き換えられるようにしました。
よろしくお願いします。