### PR TITLE
ヘッダに数値を指定していてエラーになっているのを修正

### DIFF
--- a/lib/docbase/client.rb
+++ b/lib/docbase/client.rb
@@ -136,7 +136,7 @@ module DocBase
         'Accept'         => 'application/json',
         'User-Agent'     => USER_AGENT,
         'X-DocBaseToken' => @access_token,
-        'X-Api-Version'  => 1,
+        'X-Api-Version'  => '1',
       }
     end
   end


### PR DESCRIPTION
https://github.com/krayinc/docbase-ruby/issues/8 へのAPI v1用の対応です。